### PR TITLE
XCode 11.1 OBJ-C type inference fix 

### DIFF
--- a/NUIParse.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/NUIParse.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPShiftReduceGotoTable.m
+++ b/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPShiftReduceGotoTable.m
@@ -7,7 +7,7 @@
 //
 
 #import "NUIPShiftReduceGotoTable.h"
-
+#import "NUIPRule.h"
 
 @implementation NUIPShiftReduceGotoTable
 {


### PR DESCRIPTION
In XCode 11 there are issues with infering the correct type in NUIParse, this fixes that